### PR TITLE
Corriger le port exposé

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM tahitiwebdesign/centos7-without-systemd
-LABEL maintainer="paraita@tahitiwebdesign.com"
+LABEL maintainer="dev@tahitiwebdesign.com"
 
 ENV ODOO_RPM_URL https://nightly.odoo.com/8.0/nightly/rpm/odoo_8.0.20171001.noarch.rpm
 ENV ODOO_CFG /etc/odoo/openerp-server.conf
@@ -31,7 +31,7 @@ RUN curl -Lo wkhtmltox.rpm $WKHTMLTOX_URL && \
 	yum -y localinstall wkhtmltox.rpm && \
 	ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf;
 
-EXPOSE 8089 8071
+EXPOSE 8069 8071
 
 VOLUME ["/etc/odoo", "/var/lib/odoo", "/var/log/odoo/", "/mnt/extra-addons"]
 


### PR DESCRIPTION
Le port exposé par Docker n'est pas celui qui est utilisé par Odoo.