### PR TITLE
fix: change poetry verison to 1.1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tahitiwebdesign/odoo8-base:release-1.2.0
 LABEL maintainer="dev@tahitiwebdesign.com"
 
 # Install poetry
-ENV POETRY_VERSION=1.1.9
+ENV POETRY_VERSION=1.1.8
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - && \
     echo ". $HOME/.poetry/env" >> $HOME/.bashrc
 RUN	source $HOME/.poetry/env && \


### PR DESCRIPTION
les versions supérieures poetry ne réussisent pas à récupérer des modules sur nexus
https://stackoverflow.com/questions/69836936/poetry-attributeerror-link-object-has-no-attribute-name
https://github.com/python-poetry/poetry/issues/4085